### PR TITLE
Checksum implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include $(DEVKITARM)/base_rules
 IPL_LOAD_ADDR := 0x40003000
 LPVERSION_MAJOR := 0
 LPVERSION_MINOR := 6
-LPVERSION_BUGFX := 4
+LPVERSION_BUGFX := 5
 
 ################################################################################
 

--- a/source/incognito/incognito.c
+++ b/source/incognito/incognito.c
@@ -156,19 +156,19 @@ bool calculateAndWriteCrc(u32 offset, u32 size)
 void validateChecksums(u8 *blob)
 {
     if (!validateCrc(0x0250, 0x1E, blob))
-        gfx_printf("%kWarning - invalid serial number checksum\n", COLOR_GREEN);
+        gfx_printf("%kWarning - invalid serial crc\n", COLOR_RED);
 
     if (!validateCrc(0x0480, 0x18E, blob))
-        gfx_printf("%kWarning - invalid ECC-B233 device cert checksum...\n", COLOR_RED);
+        gfx_printf("%kWarning - invalid ECC-B233 crc...\n", COLOR_RED);
 
     if (!validateCrc(0x3AE0, 0x13E, blob))
-        gfx_printf("%kWarning - invalid extended SSL key checksum...\n", COLOR_RED);
+        gfx_printf("%kWarning - invalid ext SSL key crc...\n", COLOR_RED);
 
     if (!validateCrc(0x35A0, 0x07E, blob))
-        gfx_printf("%kWarning - invalid Amiibo ECDSA cert checksum...\n", COLOR_RED);
+        gfx_printf("%kWarning - invalid ECDSA cert crc...\n", COLOR_RED);
 
     if (!validateCrc(0x36A0, 0x09E, blob))
-        gfx_printf("%kWarning - invalid Amiibo ECQV-BLS root cert checksum...\n", COLOR_RED);
+        gfx_printf("%kWarning - invalid ECQV-BLS cert crc...\n", COLOR_RED);
 }
 
 bool dump_keys()
@@ -382,17 +382,10 @@ bool dump_keys()
         return false;
     }
 
-    u32 serialOffset = 0x250;
-
     char serial[15];
-    readData((u8 *)serial, serialOffset, 14, NULL);
+    readData((u8 *)serial, 0x250, 14, NULL);
 
     gfx_printf("%kCurrent serial: [%s]\n\n", COLOR_BLUE, serial);
-
-    if (validateCrc(serialOffset, 0x1E, NULL))
-        gfx_printf("%kValid serial checksum\n", COLOR_GREEN);
-    else
-        gfx_printf("%kWarning - invalid serial checksum\n", COLOR_RED);
 
     return true;
 }
@@ -424,7 +417,6 @@ bool writeSerial()
     return calculateAndWriteCrc(serialOffset, 0x1E);
 }
 
-// todo: include crc block in sizes
 bool incognito()
 {
     gfx_printf("%kChecking if backup exists...\n", COLOR_YELLOW);
@@ -477,11 +469,11 @@ bool incognito()
         return false;
 
     gfx_printf("%kErasing RSA-2048 extended device key...\n", COLOR_YELLOW);
-    if (!erase(0x3D70, 0x240)) // seems empty & unused...
+    if (!erase(0x3D70, 0x240)) // seems empty & unused!
         return false;
 
     gfx_printf("%kErasing RSA-2048 device certificate...\n", COLOR_YELLOW);
-    if (!erase(0x3FC0, 0x240)) // seems empty & unused...
+    if (!erase(0x3FC0, 0x240)) // seems empty & unused!
         return false;
 
     gfx_printf("%kWriting SSL cert hash...\n", COLOR_YELLOW);

--- a/source/incognito/incognito.c
+++ b/source/incognito/incognito.c
@@ -402,36 +402,36 @@ bool incognito()
             return false;
     }
 
-    gfx_printf("%kWriting junk serial...\n", COLOR_YELLOW);
+    gfx_printf("%kWriting fake serial...\n", COLOR_YELLOW);
     if (!writeSerial())
         return false;
-
-    gfx_printf("%kErasing client cert...\n", COLOR_YELLOW);
-    if (!erase(0x0AE0, 0x800)) // client cert
+/*  // NOTE: This is crashing Atmosphere...
+    gfx_printf("%kErasing ECC-B233 device cert...\n", COLOR_YELLOW);
+    if (!erase(0x0480, 0x180)) // (size 0x190 to include crc)
+        return false;
+*/
+    gfx_printf("%kErasing SSL cert...\n", COLOR_YELLOW);
+    if (!erase(0x0AE0, 0x800))
         return false;
 
-    gfx_printf("%kErasing private key...\n", COLOR_YELLOW);
-    if (!erase(0x3AE0, 0x130)) // private key
+    gfx_printf("%kErasing extended SSL key...\n", COLOR_YELLOW);
+    if (!erase(0x3AE0, 0x130))
         return false;
 
-    gfx_printf("%kErasing deviceId 1/2...\n", COLOR_YELLOW);
-    if (!erase(0x35E1, 0x006)) // deviceId
+    gfx_printf("%kErasing Amiibo ECDSA cert...\n", COLOR_YELLOW);
+    if (!erase(0x35A0, 0x070))
         return false;
 
-    gfx_printf("%kErasing deviceId 2/2...\n", COLOR_YELLOW);
-    if (!erase(0x36E1, 0x006)) // deviceId
+    gfx_printf("%kErasing Amiibo ECQV-BLS root cert...\n", COLOR_YELLOW);
+    if (!erase(0x36A0, 0x090))
         return false;
 
-    gfx_printf("%kErasing device cert 1/2...\n", COLOR_YELLOW);
-    if (!erase(0x02B0, 0x180)) // device cert
+    gfx_printf("%kErasing RSA-2048 extended device key...\n", COLOR_YELLOW);
+    if (!erase(0x3D70, 0x240))
         return false;
 
-    gfx_printf("%kErasing device cert 2/2...\n", COLOR_YELLOW);
-    if (!erase(0x3D70, 0x240)) // device cert
-        return false;
-
-    gfx_printf("%kErasing device key...\n", COLOR_YELLOW);
-    if (!erase(0x3FC0, 0x240)) // device key
+    gfx_printf("%kErasing RSA-2048 device certificate...\n", COLOR_YELLOW);
+    if (!erase(0x3FC0, 0x240))
         return false;
 
     gfx_printf("%kWriting client cert hash...\n", COLOR_YELLOW);

--- a/source/incognito/incognito.c
+++ b/source/incognito/incognito.c
@@ -376,22 +376,29 @@ bool writeSerial()
     }
 
     const u32 serialOffset = 0x250;
-    const u32 serialBlockSize = 0x1E;
-
     if (!writeData((u8 *)junkSerial, serialOffset, 14, NULL))
         return false;
 
     // write crc at end of serial-number block
-    char serial[31] = "";
-    readData((u8 *)serial, serialOffset, serialBlockSize, NULL);
-
-    const char *serialBytes = serial;
-    u16 crcValue = get_crc_16(serialBytes, serialBlockSize);
-    u8 crc[2] = { crcValue & 0xff, crcValue >> 8 }; // bytes of u16
-  
-    return writeData(crc, serialOffset + serialBlockSize, 2, NULL);
+    return writeCrc(serialOffset, 0x1E);
 }
 
+bool writeCrc(u32 offset, u32 size)
+{
+    char buffer[size + 1];
+    if (!readData((u8 *)buffer, offset, size, NULL))
+        return false;
+    
+    const char *bytes = buffer;
+    free(buffer);
+    u16 crcValue = get_crc_16(bytes, size);
+    u8 crc[2] = { crcValue & 0xff, crcValue >> 8 }; // bytes of u16
+  
+    return writeData(crc, offset + size, 2, NULL);
+}
+
+// todo: write a method to add a crc!
+// todo: include crc block in sizes
 bool incognito()
 {
     gfx_printf("%kChecking if backup exists...\n", COLOR_YELLOW);

--- a/source/incognito/io/io.c
+++ b/source/incognito/io/io.c
@@ -77,6 +77,14 @@ out:;
     return res;
 }
 
+// replacement for nx_emmc_part_write in storage/nx_emmc, which uses sdmmc_storage_write
+int nx_emummc_part_write(sdmmc_storage_t *storage, emmc_part_t *part, u32 sector_off, u32 num_sectors, void *buf)
+{
+	// The last LBA is inclusive.
+	if (part->lba_start + sector_off > part->lba_end)
+		return 0;
+	return emummc_storage_write(storage, part->lba_start + sector_off, num_sectors, buf);
+}
 
 bool prodinfo_read(
     u8 *buff,   /* Data buffer to store read data */
@@ -156,13 +164,4 @@ bool prodinfo_write(
     }
 
     return false;
-}
-
-// replacement for nx_emmc_part_write in storage/nx_emmc, which uses sdmmc_storage_write
-int nx_emummc_part_write(sdmmc_storage_t *storage, emmc_part_t *part, u32 sector_off, u32 num_sectors, void *buf)
-{
-	// The last LBA is inclusive.
-	if (part->lba_start + sector_off > part->lba_end)
-		return 0;
-	return emummc_storage_write(storage, part->lba_start + sector_off, num_sectors, buf);
 }

--- a/source/incognito/io/io.c
+++ b/source/incognito/io/io.c
@@ -2,6 +2,7 @@
 
 #include "../../storage/sdmmc.h"
 #include "../../storage/nx_emmc.h"
+#include "../../storage/emummc.h"
 
 #include <string.h>
 #include "../../sec/se.h"


### PR DESCRIPTION
These changes will make it particularly obvious when restoring from an invalid backup - although they will not prevent you from doing so.

- Now calculates and adds checksums to each modified portion of calibration data
- Verifies checksums and **warns** on-screen if invalid (does not fail anything)